### PR TITLE
add maubot entrypoint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setuptools.setup(
     entry_points="""
         [console_scripts]
         mbc=maubot.cli:app
+        maubot=maubot.__main__:main
         [pytest11]
         maubot=maubot.testing
     """,


### PR DESCRIPTION
This is useful for me to avoid packaging with a direct call to python in services/daemons. Inspired by the recent addition of entry_points to synapse :)