### PR TITLE
Guard against AttributeErrors in register_handler_class()

### DIFF
--- a/maubot/plugin_base.py
+++ b/maubot/plugin_base.py
@@ -78,7 +78,14 @@ class Plugin(ABC):
     def register_handler_class(self, obj) -> None:
         warned_webapp = False
         for key in dir(obj):
-            val = getattr(obj, key)
+            try:
+                val = getattr(obj, key)
+            # It's possible for dir() to include descriptors or other
+            # attributes that can't actually be gotten (e.g., __provides__
+            # descriptors created by zope.interface), so in that case,
+            # catch the AttributeError and continue.
+            except AttributeError:
+                continue
             try:
                 if val.__mb_event_handler__:
                     for event_type in val.__mb_event_types__:


### PR DESCRIPTION
This method iterates over the attributes when starting a plugin object, but it does not account for the fact that "because dir() is supplied primarily as a convenience for use at an interactive prompt, it tries to supply an interesting set of names more than it tries to supply a rigorously or consistently defined set of names,"[1] and that attempting to getattr() some of those attributes may cause a traceback.

This fixes a rather hard to debug issue that came up in https://github.com/fedora-infra/maubot-fedora. This surfaced due to our plugin importing fedora_messaging that imports code from tornado that activates side effects in zope.interface that causes a `__provides__` descriptor that raises AttributeError when accessed from an instantiated class to be added to the `abc.ABC` class from which `Plugin` inherits.
I don't know why zope does this, but apparently this side effect has caused similar issues in other projects [2,3], which led me to the solution in this commit.

[1] https://docs.python.org/3/library/functions.html#dir
[2] https://github.com/scrapy/scrapy/issues/6307
[3] https://github.com/fivetran/great_expectations/pull/9830